### PR TITLE
Implement initial Argus monitoring backend and frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Frontend build artifacts
+webapp/node_modules/
+webapp/build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Argus
+
+Argus is a simple Linux system performance monitoring web application. The backend is written in Go using Gin and gopsutil, while the frontend is a lightweight React app. It exposes several REST APIs and periodically fetches system metrics for display.
+
+## Backend
+
+### Building and Running
+
+```bash
+go run ./cmd/argus
+```
+
+The server listens on port `8080` and provides the following endpoints:
+
+- `GET /api/cpu`
+- `GET /api/memory`
+- `GET /api/network`
+- `GET /api/process`
+
+## Frontend
+
+A very small React application is provided in `webapp/`. Open `webapp/index.html` in a browser while the backend is running to view the metrics (the page uses CDN hosted scripts).
+
+## Development
+
+This repository requires Go 1.20+ and Node (for the frontend scripts). Dependencies are referenced but not vendored. Running `go mod tidy` or installing Node packages may require Internet access.
+

--- a/cmd/argus/main.go
+++ b/cmd/argus/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/net"
+	"github.com/shirou/gopsutil/process"
+)
+
+func getCPU(c *gin.Context) {
+	loadAvg, err := load.Avg()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	cpuPercent, err := cpu.Percent(0, false)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	usage := 0.0
+	if len(cpuPercent) > 0 {
+		usage = cpuPercent[0]
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"load1":         loadAvg.Load1,
+		"load5":         loadAvg.Load5,
+		"load15":        loadAvg.Load15,
+		"usage_percent": usage,
+	})
+}
+
+func getMemory(c *gin.Context) {
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"total":        vm.Total,
+		"used":         vm.Used,
+		"free":         vm.Free,
+		"used_percent": vm.UsedPercent,
+	})
+}
+
+func getNetwork(c *gin.Context) {
+	ioCounters, err := net.IOCounters(false)
+	if err != nil || len(ioCounters) == 0 {
+		if err == nil {
+			err = gin.Error{Err: err, Type: gin.ErrorTypePublic}
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	io := ioCounters[0]
+	c.JSON(http.StatusOK, gin.H{
+		"bytes_sent":   io.BytesSent,
+		"bytes_recv":   io.BytesRecv,
+		"packets_sent": io.PacketsSent,
+		"packets_recv": io.PacketsRecv,
+	})
+}
+
+func getProcess(c *gin.Context) {
+	procs, err := process.Processes()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	result := []gin.H{}
+	for _, p := range procs {
+		name, err := p.Name()
+		if err != nil {
+			continue
+		}
+		cpuP, err := p.CPUPercent()
+		if err != nil {
+			continue
+		}
+		memP, err := p.MemoryPercent()
+		if err != nil {
+			continue
+		}
+		result = append(result, gin.H{
+			"pid":         p.Pid,
+			"name":        name,
+			"cpu_percent": cpuP,
+			"mem_percent": memP,
+		})
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func main() {
+	router := gin.Default()
+	router.GET("/api/cpu", getCPU)
+	router.GET("/api/memory", getMemory)
+	router.GET("/api/network", getNetwork)
+	router.GET("/api/process", getProcess)
+
+	router.Run(":8080")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module argus
+
+go 1.23.8

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -1,0 +1,28 @@
+const { useState, useEffect } = React;
+
+function App() {
+  const [cpu, setCpu] = useState(null);
+  const [memory, setMemory] = useState(null);
+  const [network, setNetwork] = useState(null);
+  const [processes, setProcesses] = useState([]);
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  function fetchData() {
+    fetch('/api/cpu').then(r => r.json()).then(setCpu).catch(console.error);
+    fetch('/api/memory').then(r => r.json()).then(setMemory).catch(console.error);
+    fetch('/api/network').then(r => r.json()).then(setNetwork).catch(console.error);
+    fetch('/api/process').then(r => r.json()).then(setProcesses).catch(console.error);
+  }
+
+  return React.createElement('div', null,
+    React.createElement('h1', null, 'Argus Monitor'),
+    React.createElement('pre', null, JSON.stringify({cpu, memory, network, processes}, null, 2))
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Argus Monitor</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Go module and implement backend API endpoints
- add a minimal React front-end under `webapp`
- document build and run instructions in `README.md`
- ignore frontend build artifacts

## Testing
- `gofmt -w cmd/argus/main.go`
- `go vet ./...` *(fails: no required module provides package github.com/gin-gonic/gin)*
- `go test ./...` *(fails: no required module provides package github.com/gin-gonic/gin)*

------
https://chatgpt.com/codex/tasks/task_e_6864f644c4f4833199478e0da5c8add3